### PR TITLE
Address suggestions from the meeting of Jan 13

### DIFF
--- a/pypom/exception.py
+++ b/pypom/exception.py
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+class UsageError(Exception):
+    """A custom exception for use by PyPOM."""
+    pass

--- a/pypom/page.py
+++ b/pypom/page.py
@@ -2,45 +2,90 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import sys
+
+from .exception import UsageError
 from .view import WebView
+
+if sys.version_info >= (3,):
+    from urllib.parse import urljoin
+else:
+    from urlparse import urljoin
 
 
 class Page(WebView):
 
-    _url = '{base_url}'
+    URL_TEMPLATE = None
     """String representing a URL that will return this page.
 
     This string is formatted and can contain names of keyword arguments passed
-    during construcion of the page object. The ``{base_url}`` keyword argument
-    is always passed to the format operation.
+    during construction of the page object. The template should either assume
+    that its result will be appended to the value of ``base_url``,
+    or should yield an absolute URL.
     """
 
-    def open(self):
-        """
-        Navigates to the URL returned by the :py:func:`url` property and
-        waits for the page to load by calling :py:func:`wait_for_page_to_load`.
-
-        :returns:
-            The current page object (i.e., ``self``).
-        """
-        self.selenium.get(self.url)
-        self.wait_for_page_to_load()
-        return self
-
     @property
-    def url(self):
+    def canonical_url(self):
         """
-        Returns the URL to the current page, formatted from :py:data:`_url`.
+        Returns the URL to the current page,
+        formatted from :py:data:`URL_TEMPLATE`.
+        Unless URL_TEMPLATE results in an absolute URL, ``self.base_url`` is
+        prepended to the resulting URL.
 
         :returns:
             String representing a URL that will return this page.
         """
-        return self._url.format(base_url=self.base_url, **self.kwargs)
+        if self.URL_TEMPLATE is not None:
+            return urljoin(self.base_url,
+                           self.URL_TEMPLATE.format(**self.url_kwargs))
+        return self.base_url
+
+    def find_element(self, locator):
+        """
+        Calls ``selenium.find_element``.
+
+        :param locator:
+            A locator that Selenium can understand.
+
+        :returns:
+            The first WebElement found using ``locator``.
+        """
+        return self.selenium.find_element(*locator)
+
+    def find_elements(self, locator):
+        """
+        Calls ``selenium.find_elements``.
+
+        :param locator:
+            A locator that Selenium can understand.
+
+        :returns:
+            A list of all WebElements found using ``locator``.
+        """
+        return self.selenium.find_elements(*locator)
+
+    def open(self):
+        """
+        Navigates to the URL returned by the :py:func:`canonical_url` property
+        and waits for the page to load
+        by calling :py:func:`wait_for_page_to_load`.
+
+        :returns:
+            The current page object (i.e., ``self``).
+        """
+        if self.canonical_url:
+            self.selenium.get(self.canonical_url)
+            self.wait_for_page_to_load()
+            return self
+        raise UsageError('The canonical_url for the page is empty.\n'
+                         'Calling open() on the page will result in a blank'
+                         'browser page and therefore does not make sense.')
 
     def wait_for_page_to_load(self):
         """
         Waits for the page to load by waiting until the URL reported by
-        Selenium is the same as that returned by the :py:func:`url` property.
+        Selenium is the same as that returned by the :py:func:`canonical_url`
+        property, if the :py:func:`canonical_url` property has a value.
 
         Note that it is common to extend or override this method
         to provide custom wait behaviour.
@@ -48,5 +93,6 @@ class Page(WebView):
         :returns:
             The current page object (i.e., ``self``).
         """
-        self.wait.until(lambda s: self.url in s.current_url)
+        if self.canonical_url:
+            self.wait.until(lambda s: self.canonical_url in s.current_url)
         return self

--- a/pypom/region.py
+++ b/pypom/region.py
@@ -15,7 +15,7 @@ class Region(WebView):
     Defaults to ``None``.
     """
 
-    def __init__(self, page, root=None, **kwargs):
+    def __init__(self, page, root=None):
         """
         :param page:
             The page object in which this Region is contained.
@@ -25,11 +25,10 @@ class Region(WebView):
             operate for this Region.
 
             Defaults to ``None`` which results in the root being Selenium.
-
-        :param kwargs:
-            Dictionary of arguments to pass into the parent's ``__init__``.
         """
-        super(Region, self).__init__(page.base_url, page.selenium, **kwargs)
+        super(Region, self).__init__(page.selenium,
+                                     page.base_url,
+                                     page.timeout)
         self._root_element = root
         self.page = page
 
@@ -39,7 +38,7 @@ class Region(WebView):
         Returns the root from which Selenium find commands will
         operate for this Region.
 
-        If a ``root_element`` was passed into the constructor,
+        If a ``root`` was passed into the constructor,
         that element will be returned as the root.
         If a locator was specified in :py:data:`_root_locator`,
         the element found using that locator will be returned as the root.
@@ -51,3 +50,29 @@ class Region(WebView):
                 return self.selenium.find_element(*self._root_locator)
             return self.selenium
         return self._root_element
+
+    def find_element(self, locator):
+        """
+        Calls ``find_element`` on ``self.root`` which is either an instance
+        of Selenium or a WebElement.
+
+        :param locator:
+            A locator that Selenium can understand.
+
+        :returns:
+            The first WebElement found using ``locator``.
+        """
+        return self.root.find_element(*locator)
+
+    def find_elements(self, locator):
+        """
+        Calls ``find_elements`` on ``self.root`` which is either an instance
+        of Selenium or a WebElement.
+
+        :param locator:
+            A locator that Selenium can understand.
+
+        :returns:
+            A list of all WebElements found using ``locator``.
+        """
+        return self.root.find_elements(*locator)

--- a/pypom/view.py
+++ b/pypom/view.py
@@ -12,66 +12,30 @@ class WebView(object):
      and :class:`pypom.region.Region` classes
      """
 
-    def __init__(self, base_url, selenium, **kwargs):
+    def __init__(self, selenium, base_url=None, timeout=0, **url_kwargs):
         """
-        :param base_url:
-            The base URL for the site on which the test is being run.
-
         :param selenium:
             An instance of the Selenium class.
 
-        :param kwargs:
+        :param base_url:
+            The base URL for the site on which the test is being run.
+
+            Defaults to ``None``.
+
+        :param timeout:
+            The timeout, in seconds, to be used for calls to ``self.wait``.
+
+            Defaults to ``0``.
+
+        :param url_kwargs:
             Dictionary of arguments to add to the URL when generated.
         """
 
-        self.base_url = base_url
         self.selenium = selenium
+        self.base_url = base_url
+        self.timeout = timeout
         self.wait = WebDriverWait(self.selenium, self.timeout)
-        self.kwargs = kwargs
-
-    @property
-    def root(self):
-        """
-        The root from which Selenium commands are issued.
-
-        Defaults to ``self.selenium`` for page objects.
-        """
-        return self.selenium
-
-    @property
-    def timeout(self):
-        """
-        The timeout, in seconds, to be used for calls to ``self.wait``.
-
-        Defaults to ``0``.
-        """
-        return 0
-
-    def find_element(self, locator):
-        """
-        Calls ``find_element`` on ``self.root`` which is either an instance
-        of Selenium or a WebElement.
-
-        :param locator:
-            A locator that Selenium can understand.
-
-        :returns:
-            The first WebElement found using ``locator``.
-        """
-        return self.root.find_element(*locator)
-
-    def find_elements(self, locator):
-        """
-        Calls ``find_elements`` on ``self.root`` which is either an instance
-        of Selenium or a WebElement.
-
-        :param locator:
-            A locator that Selenium can understand.
-
-        :returns:
-            A list of all WebElements found using ``locator``.
-        """
-        return self.root.find_elements(*locator)
+        self.url_kwargs = url_kwargs
 
     def is_element_present(self, locator):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import random
-
 from mock import Mock
 import pytest
 
 
 @pytest.fixture
 def base_url():
-    return str(random.random())
+    return 'https://www.mozilla.org/'
 
 
 @pytest.fixture
@@ -21,9 +19,9 @@ def element(selenium):
 
 
 @pytest.fixture
-def page(base_url, selenium):
+def page(selenium, base_url):
     from pypom import Page
-    return Page(base_url, selenium)
+    return Page(selenium, base_url)
 
 
 @pytest.fixture


### PR DESCRIPTION
Make base_url optional, and reorder arguments to place selenium first
Rename _url to URL_TEMPLATE
Rename url to target_url
Prepend base_url to the result of URL_TEMPLATE if it does not result in an absolute URL
Rename kwargs to url_kwargs
Remove timeout property and replace with an argument to WebView.__init__
Move find_element* methods into Page and Region
In wait_for_page_to_load, only perform the URL check if target_url yields a value
Add/change tests for new/changed functionality